### PR TITLE
Hot fix relative search path bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "diatom"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diatom"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [ "Terence Ng", "Aoyang Yu" ]
 description = "The diatom programming language"


### PR DESCRIPTION
Relative search path incorrectly includes all file opened on stack.
Now it will only include current file.